### PR TITLE
Upgrade to processing 1.4.8.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -27,6 +27,45 @@ fs.readFile(sketch, function(err, data) {
 });
 ```
 
+## Usage
+
+```javascript
+// Compile processing code into javascript, so it can be used in a LAMP webapp more effectively (no p5 lang parsing step by client needed)
+// Intended to use with Grunt when developing and deploying web applications
+// contribution by kroko.me
+
+var fs = require('fs');
+var p5 = require('processing');
+if (process.argv.length != 5) {
+    console.log("Usage: node compile.js <input-sketch.pde> <output-filename.js> <variable-name-to-store-p5js-app-into>");
+    process.exit(code = 1);
+}
+else {
+    console.log("Reading file: " + process.argv[2]);
+    console.log("Output will be: " + process.argv[3]);
+    console.log("Variable will be: " + process.argv[4]);
+}
+console.log("Compiling sketch...");
+
+fs.readFile(process.argv[2], function(err, data) {
+    var compiled = p5.Processing.compile(data.toString('utf-8'));
+    compiled = "var " + process.argv[4] + " = " + compiled + ";";
+    fs.writeFile(process.argv[3], compiled, function(err) {
+        if (err) {
+            console.log(err);
+        } else {
+            console.log("...done!");
+        }
+    });
+});
+
+// Usage in web
+// var domCanvas = document.getElementById('id-of-canvas-dom-element');
+// pjsPtr = new Processing(domCanvas, valiable-name-as-passed-to-this-script);
+// if (pjsPtr) { }
+```
+
+
 ## Authors
 
   - Seiya Konno &lt;seiya@uniba.jp&gt; ([nulltask](https://github.com/nulltask))

--- a/examples/compile/compile.js
+++ b/examples/compile/compile.js
@@ -1,0 +1,33 @@
+// Compile processing code into javascript, so that can be used in webpage more effectively (no p5 lang parsing step by client needed)
+// Intended to use with Grunt when developing and deploying web applications
+// contribution by kroko.me
+
+var fs = require('fs');
+var p5 = require('processing');
+if (process.argv.length != 5) {
+    console.log("Usage: node compile.js <input_sketch.pde> <output_filename.js> <variable_name_to_store_p5js_app_into>");
+    process.exit(code = 1);
+}
+else {
+    console.log("Reading file: " + process.argv[2]);
+    console.log("Output will be: " + process.argv[3]);
+    console.log("Variable will be: " + process.argv[4]);
+}
+console.log("Compiling sketch...");
+
+fs.readFile(process.argv[2], function(err, data) {
+    var compiled = p5.Processing.compile(data.toString('utf-8'));
+    compiled = "var " + process.argv[4] + " = " + compiled + ";";
+    fs.writeFile(process.argv[3], compiled, function(err) {
+        if (err) {
+            console.log(err);
+        } else {
+            console.log("...done!");
+        }
+    });
+});
+
+// Usage in web
+// var domCanvas = document.getElementById('id_of_canvas_dom_element');
+// pjsPtr = new Processing(domCanvas, valiable_name_as_passed_to_this_script);
+// if (pjsPtr) { }

--- a/lib/processing.js
+++ b/lib/processing.js
@@ -57,7 +57,7 @@ eval('(function(window, document) {'
  * Expose `Processing`.
  */
 
-exports.Processing = Processing;
+exports.Processing = window.Processing;
 
 /**
  * Return processing instance.

--- a/lib/processing.js
+++ b/lib/processing.js
@@ -16,7 +16,7 @@ var fs = require('fs')
   , navigator = window.navigator
   , HTMLImageElement = window.HTMLImageElement
   , noop = function() {}
-  , processing = fs.readFileSync('./deps/processing-js/processing.js');
+  , processing = fs.readFileSync(__dirname+'/../deps/processing-js/processing.js');
 
 /**
  * Expose `version`.


### PR DESCRIPTION
Fixed relative path in lib/processing.js
Upgraded submodule to Processingjs 1.4.8.
Added example for how to use this module to compile pde sketch into javascript that can be used in LAMP webapplication.
Apparently the change in lib/processing.js breaks your scribbleplotter example, this needs investigation. A quick diff shows that processing structure has changed a lot, i.e., Processing object now under window object.
